### PR TITLE
Use absolute http urls to the SDK page until we get a SSL certificate…

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
           <a href="https://github.com/AllenInstitute">GitHub Profile</a> |
           <a href="https://alleninstitute.org/">Allen Institute for Brain Science</a> |
           <a href="http://brain-map.org/">Allen Brain Atlas</a> |
-          <a href="https://alleninstitute.github.io/AllenSDK">Allen SDK</a>
+          <a href="http://alleninstitute.github.io/AllenSDK">Allen SDK</a>
         </p>
       </header>
 
@@ -47,7 +47,7 @@
         <h2> Allen SDK </h2>
 
         <p>
-          The Allen Institute for Brain Science has published the <a href="/AllenSDK">Allen Software Development Kit (SDK)</a>, 
+          The Allen Institute for Brain Science has published the <a href="http://alleninstitute.github.io/AllenSDK">Allen Software Development Kit (SDK)</a>, 
           which houses source code for reading and processing Allen Brain Atlas data.  
           The Allen SDK focuses primarily on tools and analysis associated with the Allen Cell Types Database, Mouse Connectivity 
 	  Atlas, and Allen Brain Observatory. 
@@ -59,7 +59,7 @@
           The Allen Institute for Brain Science offers access to its published data through an 
 	  <a href="http://api.brain-map.org/">application programming interface (API)</a>. The API, documentation, and sample applications
 	  are made available to the community under the Allen Institute's <a href="http://alleninstitute.org/terms-of-use/">Terms of Use</a>. 
-	  The <a href="/AllenSDK">Allen SDK</a> provides Python classes, notebooks, and code samples to facilitate API use.
+	  The <a href="http://alleninstitute.github.io/AllenSDK">Allen SDK</a> provides Python classes, notebooks, and code samples to facilitate API use.
         </p>
 	
 	<h2> Research & Publications </h2>


### PR DESCRIPTION
# What does this PR do?
Changes the links on the homepage to use absolute http urls for the SDK page.

# Where are the assets being defined?

We currently specify the http includes here: https://github.com/AllenInstitute/AllenSDK/blob/master/doc_template/aibs_sphinx/templates/portalHeader.html 
 
Which causes a mixed content error when accessing https://alleninstitute.github.io/AllenSDK

```
Mixed Content: The page at 'https://alleninstitute.github.io/AllenSDK/' was loaded over HTTPS, but requested an insecure stylesheet 'http://www.brain-map.org/assets/stylesheets/portal.css'. This request has been blocked; the content must be served over HTTPS.
```

# Long term fix

Update the sdk portal header template to use HTTPS links once we have a SSL certificate on brain-map.org.